### PR TITLE
Update .htaccess with versioning support and main branch references

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -1,25 +1,33 @@
 RewriteEngine On
 
+# Extract version from the path: /v1.0.0/
+RewriteCond %{REQUEST_URI} ^/([^/]+)/?(index\.html)?$
+RewriteRule ^([^/]+)/?(index\.html)?$ - [E=VERSION:%1]
+
 # HTML
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
 RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
-RewriteRule ^(index\.html)?$ https://aiaont.github.io/aiao/aiao.html [R=303,L]
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://aiaont.github.io/aiao/aiao.html?v=%{ENV:VERSION} [R=303,L]
 
 # JSON-LD
 RewriteCond %{HTTP_ACCEPT} application/json [OR]
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
-RewriteRule ^(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@cjp2/aiao.jsonld [R=303,L]
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@%{ENV:VERSION}/aiao.jsonld [R=303,L]
 
 # Turtle
 RewriteCond %{HTTP_ACCEPT} text/turtle
-RewriteRule ^(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@cjp2/aiao.ttl [R=303,L]
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@%{ENV:VERSION}/aiao.ttl [R=303,L]
 
 # RDF/XML
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
-RewriteRule ^(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@main/aiao.owl [R=303,L]
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@%{ENV:VERSION}/aiao.owl [R=303,L]
 
-# Fallback
+# Fallback to latest if no version in path
 RewriteRule ^(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/aiao@main/aiao.owl [R=303,L]
 


### PR DESCRIPTION
- Added version extraction from URL paths (/v1.0.0/)
- Implemented dynamic routing using extracted version
- Fixed inconsistent branch references (cjp2 -> main)
- Added version parameter to HTML documentation URLs
- Enhanced URL patterns to support versioned requests
- Maintained fallback to @main for unversioned requests